### PR TITLE
support multiprocessing and pmc file removal to save disk space

### DIFF
--- a/llava/data/download_images.py
+++ b/llava/data/download_images.py
@@ -1,49 +1,49 @@
 import os
 import json
 import shutil
-from tqdm import tqdm
 import tarfile
 import argparse
 from urllib.error import HTTPError
 import urllib.request
+from multiprocessing import Pool
+import multiprocessing as mp
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--input_path', type=str, default='data/llava_med_image_urls.jsonl')
+parser.add_argument('--pmc_output_path', type=str, default='data/pmc_articles/')
+parser.add_argument('--images_output_path', type=str, default='data/images/')
+parser.add_argument('--remove_pmc', action='store_true', default=False, help='remove pmc articles after image extraction')
+parser.add_argument('--cpus', type=int, default=-1, help='number of cpus to use in multiprocessing (default: all)')
+args = parser.parse_args()
 
-def main(args):
-  input_data = []
-  with open(args.input_path) as f:
+input_data = []
+with open(args.input_path) as f:
     for line in f:
-      input_data.append(json.loads(line))
+        input_data.append(json.loads(line))
 
-  # Download all PMC articles
-  print('Downloading PMC articles')
-  for idx, sample in enumerate(tqdm(input_data)):
+def download_func(idx):
+    sample = input_data[idx]
     try:
-      urllib.request.urlretrieve(sample['pmc_tar_url'], os.path.join(args.pmc_output_path, os.path.basename(sample['pmc_tar_url'])))
-    except HTTPError as e:
-      print('Error downloading PMC article: {}'.format(sample['pmc_tar_url']))
-      continue
-
-
-  # Untar all PMC articles
-  print('Untarring PMC articles')
-  for sample in tqdm(input_data):
-    fname = os.path.join(args.pmc_output_path, os.path.basename(os.path.join(sample['pmc_tar_url'])))
-    tar = tarfile.open(fname, "r:gz")
-    tar.extractall(args.pmc_output_path)
-    tar.close()
+        urllib.request.urlretrieve(sample['pmc_tar_url'], os.path.join(args.pmc_output_path, os.path.basename(sample['pmc_tar_url'])))
+        fname = os.path.join(args.pmc_output_path, os.path.basename(os.path.join(sample['pmc_tar_url'])))
+        
+        tar = tarfile.open(fname, "r:gz")
+        tar.extractall(args.pmc_output_path)
+        tar.close()
+        src = os.path.join(args.pmc_output_path, sample['image_file_path'])
+        dst = os.path.join(args.images_output_path, sample['pair_id']+'.jpg')
+        shutil.copyfile(src, dst)  
+        if args.remove_pmc:
+            os.remove(fname)
+            shutil.rmtree(os.path.join(args.pmc_output_path, str(os.path.basename(sample['pmc_tar_url']))).split('.tar.gz')[0]+'/')
+    except Exception as e:
+        print(e)
+        
+if args.cpus == -1:
+    cpus = mp.cpu_count()
+else:
+    cpus = args.cpus
     
-  # Copy to images directory
-  print('Copying images')
-  for sample in tqdm(input_data):
-    src = os.path.join(args.pmc_output_path, sample['image_file_path'])
-    dst = os.path.join(args.images_output_path, sample['pair_id']+'.jpg')
-    shutil.copyfile(src, dst)
-      
+pool = Pool(cpus)
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--input_path', type=str, default='data/llava_med_image_urls.jsonl')
-    parser.add_argument('--pmc_output_path', type=str, default='data/pmc_articles/')
-    parser.add_argument('--images_output_path', type=str, default='data/images/')
-    args = parser.parse_args()
-    main(args)
+pool.map(download_func, range(0, len(input_data)))


### PR DESCRIPTION
For faster download of pmc articles and image extraction, I've applied multiprocessing.

I've also added additional flag that removes pmc_articles after image extraction to save disk space.